### PR TITLE
Constructor Support, Address Properties

### DIFF
--- a/Testing/Expected/getAbiDeclaration.ts
+++ b/Testing/Expected/getAbiDeclaration.ts
@@ -2,7 +2,6 @@ export const getAbiDecTest0 = `export interface ITest0{
 }
 export interface ITest0Connected {
 address: string
-balance: ABIFuncParamlessCallConnected
 }
 export type ITest0Constructor = ABIFuncParamlessSendConnected
 `
@@ -11,37 +10,34 @@ export const getAbiDecTest1 = `export interface ITest1{
 }
 export interface ITest1Connected {
 address: string
-balance: ABIFuncParamlessCallConnected
 }
 export type ITest1Constructor = ABIFuncParamlessSendConnected
 `
 
 export const getAbiDecTest2 = `export interface ITest2{
-function1: ABIFuncSend<{a: string}>
-function2: ABIFuncSend<{a: string,b: BN}>
-function3: ABIFuncSend<{a: string,b: BN}>
+function1: ABIFuncSend<{a: string | Buffer}>
+function2: ABIFuncSend<{a: string | Buffer,b: BN | Buffer}>
+function3: ABIFuncSend<{a: string | Buffer,b: BN | Buffer}>
 function0: ABIFuncParamlessSend
 }
 export interface ITest2Connected {
 address: string
-balance: ABIFuncParamlessCallConnected
-function1: ABIFuncSendConnected<{a: string}>;
-function2: ABIFuncSendConnected<{a: string,b: BN}>;
-function3: ABIFuncSendConnected<{a: string,b: BN}>;
+function1: ABIFuncSendConnected<{a: string | Buffer}>;
+function2: ABIFuncSendConnected<{a: string | Buffer,b: BN | Buffer}>;
+function3: ABIFuncSendConnected<{a: string | Buffer,b: BN | Buffer}>;
 function0: ABIFuncParamlessSendConnected;
 }
 export type ITest2Constructor = ABIFuncParamlessSendConnected
 `
 
 export const getAbiDecTest3 = `export interface ITest3{
-overloaded: ABIFuncSend<{a: string}> | ABIFuncSend<{a: BN}>
-Test1: ABIFuncParamlessSend
+overloaded: ABIFuncSend<{a: string | Buffer}> | ABIFuncSend<{a: BN | Buffer}>
+Test3: ABIFuncParamlessSend
 }
 export interface ITest3Connected {
 address: string
-balance: ABIFuncParamlessCallConnected
-overloaded: ABIFuncSendConnected<{a: string}> | ABIFuncSendConnected<{a: BN}>
-Test1: ABIFuncParamlessSendConnected;
+overloaded: ABIFuncSendConnected<{a: string | Buffer}> | ABIFuncSendConnected<{a: BN | Buffer}>
+Test3: ABIFuncParamlessSendConnected;
 }
 export type ITest3Constructor = never
 `

--- a/Testing/Expected/getAbiDeclaration.ts
+++ b/Testing/Expected/getAbiDeclaration.ts
@@ -1,0 +1,47 @@
+export const getAbiDecTest0 = `export interface ITest0{
+}
+export interface ITest0Connected {
+address: string
+balance: ABIFuncParamlessCallConnected
+}
+export type ITest0Constructor = ABIFuncParamlessSendConnected
+`
+
+export const getAbiDecTest1 = `export interface ITest1{
+}
+export interface ITest1Connected {
+address: string
+balance: ABIFuncParamlessCallConnected
+}
+export type ITest1Constructor = ABIFuncParamlessSendConnected
+`
+
+export const getAbiDecTest2 = `export interface ITest2{
+function1: ABIFuncSend<{a: string}>
+function2: ABIFuncSend<{a: string,b: BN}>
+function3: ABIFuncSend<{a: string,b: BN}>
+function0: ABIFuncParamlessSend
+}
+export interface ITest2Connected {
+address: string
+balance: ABIFuncParamlessCallConnected
+function1: ABIFuncSendConnected<{a: string}>;
+function2: ABIFuncSendConnected<{a: string,b: BN}>;
+function3: ABIFuncSendConnected<{a: string,b: BN}>;
+function0: ABIFuncParamlessSendConnected;
+}
+export type ITest2Constructor = ABIFuncParamlessSendConnected
+`
+
+export const getAbiDecTest3 = `export interface ITest3{
+overloaded: ABIFuncSend<{a: string}> | ABIFuncSend<{a: BN}>
+Test1: ABIFuncParamlessSend
+}
+export interface ITest3Connected {
+address: string
+balance: ABIFuncParamlessCallConnected
+overloaded: ABIFuncSendConnected<{a: string}> | ABIFuncSendConnected<{a: BN}>
+Test1: ABIFuncParamlessSendConnected;
+}
+export type ITest3Constructor = never
+`

--- a/Testing/Expected/index.ts
+++ b/Testing/Expected/index.ts
@@ -1,0 +1,2 @@
+export * from './getAbiDeclaration'
+export * from './parseAbi'

--- a/Testing/Expected/parseAbi.ts
+++ b/Testing/Expected/parseAbi.ts
@@ -1,0 +1,137 @@
+export const parseAbiTest0 = {
+  constructorFunction: {
+    inputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'constructor'
+  },
+  overloadedFunctions: {},
+  regularFunctions: {}
+};
+
+export const parseAbiTest1 = {
+  constructorFunction: {
+    inputs: [{ name: 'a', type: 'uint256' }, { name: 'b', type: 'bytes32' }],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'constructor'
+  },
+  overloadedFunctions: {},
+  regularFunctions: {}
+};
+
+export const parseAbiTest2 = {
+  constructorFunction: {
+    inputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'constructor'
+  },
+  regularFunctions: {
+    function0: {
+      constant: false,
+      inputs: [],
+      outputs: [],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    function1: {
+      constant: false,
+      inputs: [
+        {
+          name: 'a',
+          type: 'bytes32'
+        }
+      ],
+      outputs: [],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    function2: {
+      constant: false,
+      inputs: [
+        {
+          name: 'a',
+          type: 'bytes32'
+        },
+        {
+          name: 'b',
+          type: 'uint256'
+        }
+      ],
+      outputs: [],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    function3: {
+      constant: false,
+      inputs: [
+        {
+          name: 'a',
+          type: 'bytes32'
+        },
+        {
+          name: 'b',
+          type: 'uint256'
+        }
+      ],
+      outputs: [
+        {
+          name: '',
+          type: 'int256'
+        }
+      ],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    }
+  },
+  overloadedFunctions: {}
+};
+
+export const parseAbiTest3 = {
+  constructorFunction: {},
+  overloadedFunctions: {
+    overloaded: [
+      {
+        constant: false,
+        inputs: [
+          {
+            name: 'a',
+            type: 'bytes32'
+          }
+        ],
+        outputs: [],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function'
+      },
+      {
+        constant: false,
+        inputs: [
+          {
+            name: 'a',
+            type: 'uint256'
+          }
+        ],
+        outputs: [],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function'
+      }
+    ]
+  },
+  regularFunctions: {
+    Test1: {
+      constant: false,
+      inputs: [],
+      outputs: [],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    }
+  }
+};

--- a/Testing/Expected/parseAbi.ts
+++ b/Testing/Expected/parseAbi.ts
@@ -125,7 +125,7 @@ export const parseAbiTest3 = {
     ]
   },
   regularFunctions: {
-    Test1: {
+    Test3: {
       constant: false,
       inputs: [],
       outputs: [],

--- a/Testing/__tests__/getAbiDeclaration.spec.ts
+++ b/Testing/__tests__/getAbiDeclaration.spec.ts
@@ -1,5 +1,12 @@
-import { getAbiDeclaration } from '../../lib/src/builder/getAbiDeclaration';
-import { getAbiDecTest0, getAbiDecTest1, getAbiDecTest2 , getAbiDecTest3} from '../Expected';
+import { getAbiDeclaration, parseAbi } from '../../lib/src/builder';
+import { getAbiDecTest0, 
+				 getAbiDecTest1, 
+				 getAbiDecTest2,
+				 getAbiDecTest3, 
+				 parseAbiTest0, 
+				 parseAbiTest1, 
+				 parseAbiTest2, 
+				 parseAbiTest3 } from '../Expected';
 
 const test0File = require('../abis/test0.json')
 const test1File = require('../abis/test1.json')

--- a/Testing/__tests__/getAbiDeclaration.ts
+++ b/Testing/__tests__/getAbiDeclaration.ts
@@ -1,0 +1,25 @@
+import { getAbiDeclaration } from '../../lib/src/builder/getAbiDeclaration';
+import { getAbiDecTest0, getAbiDecTest1, getAbiDecTest2 , getAbiDecTest3} from '../Expected';
+
+const test0File = require('../abis/test0.json')
+const test1File = require('../abis/test1.json')
+const test2File = require('../abis/test2.json')
+const test3File = require('../abis/test3.json')
+
+describe('getAbiDeclaration', () => {
+	it('should compile a blank constructor to a correct declaration', () => { //(abi: any, interfaceName: string, outputFile: string)
+		expect(getAbiDeclaration(test0File, 'Test0')).toEqual(getAbiDecTest0)
+	})
+
+	it('should compule a constructor with parameters to a correct declaration', () => {
+		expect(getAbiDeclaration(test1File, 'Test1')).toEqual(getAbiDecTest1)
+	})
+
+	it('should compile a contract with functions to a correct declaration', () => {
+		expect(getAbiDeclaration(test2File, 'Test2')).toEqual(getAbiDecTest2)
+	})
+
+	it('should compile a contract with overloaded functions to a correct declaration', () => {
+		expect(getAbiDeclaration(test3File, 'Test3')).toEqual(getAbiDecTest3)
+	})
+})

--- a/Testing/__tests__/parseAbi.spec.ts
+++ b/Testing/__tests__/parseAbi.spec.ts
@@ -1,6 +1,12 @@
-import { parseAbi } from './../../lib/src/builder/getAbiDeclaration'; //TODO resolve pathing
-import { getAbiDeclaration } from '../../lib/src/builder/getAbiDeclaration';
-import { parseAbiTest0, parseAbiTest1, parseAbiTest2, parseAbiTest3 } from '../Expected';
+import { getAbiDeclaration, parseAbi } from '../../lib/src/builder';
+import { getAbiDecTest0, 
+				 getAbiDecTest1, 
+				 getAbiDecTest2,
+				 getAbiDecTest3, 
+				 parseAbiTest0, 
+				 parseAbiTest1, 
+				 parseAbiTest2, 
+				 parseAbiTest3 } from '../Expected';
 
 const test0File = require('../abis/test0.json')
 const test1File = require('../abis/test1.json')

--- a/Testing/__tests__/parseAbi.ts
+++ b/Testing/__tests__/parseAbi.ts
@@ -1,0 +1,26 @@
+import { parseAbi } from './../../lib/src/builder/getAbiDeclaration'; //TODO resolve pathing
+import { getAbiDeclaration } from '../../lib/src/builder/getAbiDeclaration';
+import { parseAbiTest0, parseAbiTest1, parseAbiTest2, parseAbiTest3 } from '../Expected';
+
+const test0File = require('../abis/test0.json')
+const test1File = require('../abis/test1.json')
+const test2File = require('../abis/test2.json')
+const test3File = require('../abis/test3.json')
+
+describe('parseAbi', () => {
+	it('should parse an abi with a blank constructor into an appropriate object', () => {
+		expect(parseAbi(test0File)).toEqual(parseAbiTest0)
+	})
+
+	it('should parse an abi with a constructor (that takes arguments) into an appropriate object', () => {
+		expect(parseAbi(test1File)).toEqual(parseAbiTest1)
+	})
+
+	it('should parse an abi with functions into an appropriate object', () => {
+		expect(parseAbi(test2File)).toEqual(parseAbiTest2)
+	})
+
+	it('should parse an abi with overloaded functions into an appropriate object', () => {
+		expect(parseAbi(test3File)).toEqual(parseAbiTest3)
+	})
+})

--- a/Testing/abis/Test0.json
+++ b/Testing/abis/Test0.json
@@ -1,0 +1,8 @@
+[
+	{
+		"inputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "constructor"
+	}
+]

--- a/Testing/abis/Test1.json
+++ b/Testing/abis/Test1.json
@@ -1,0 +1,17 @@
+[
+	{
+		"inputs": [
+			{
+				"name": "a",
+				"type": "uint256"
+			},
+			{
+				"name": "b",
+				"type": "bytes32"
+			}
+		],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "constructor"
+	}
+]

--- a/Testing/abis/Test2.json
+++ b/Testing/abis/Test2.json
@@ -1,0 +1,72 @@
+[
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "a",
+				"type": "bytes32"
+			}
+		],
+		"name": "function1",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "a",
+				"type": "bytes32"
+			},
+			{
+				"name": "b",
+				"type": "uint256"
+			}
+		],
+		"name": "function2",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "a",
+				"type": "bytes32"
+			},
+			{
+				"name": "b",
+				"type": "uint256"
+			}
+		],
+		"name": "function3",
+		"outputs": [
+			{
+				"name": "",
+				"type": "int256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [],
+		"name": "function0",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "constructor"
+	}
+]

--- a/Testing/abis/Test3.json
+++ b/Testing/abis/Test3.json
@@ -1,0 +1,39 @@
+[
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "a",
+				"type": "uint256"
+			}
+		],
+		"name": "overloaded",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [],
+		"name": "Test1",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "a",
+				"type": "bytes32"
+			}
+		],
+		"name": "overloaded",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	}
+]

--- a/Testing/abis/Test3.json
+++ b/Testing/abis/Test3.json
@@ -16,7 +16,7 @@
 	{
 		"constant": false,
 		"inputs": [],
-		"name": "Test1",
+		"name": "Test3",
 		"outputs": [],
 		"payable": false,
 		"stateMutability": "nonpayable",

--- a/lib/src/builder/getAbiDeclaration.ts
+++ b/lib/src/builder/getAbiDeclaration.ts
@@ -1,17 +1,8 @@
 import { defaultProperties } from './staticContent';
 import { FunctionDefinition } from '../Types/AbiTypes';
 import { getPath, getName, getDetails } from './utils'
+import { parseAbi } from './parseAbi'
 import { Output } from '../io';
-
-declare interface AbiObject {
-	constructorFunction: FunctionDefinition
-	overloadedFunctions: {
-		[func: string]: FunctionDefinition[]
-	}
-	regularFunctions: {
-		[func: string]: FunctionDefinition
-	}
-}
 
 export const getAbiDeclaration = (abi: any, interfaceName: string): string => {
  let abiTypings = '';
@@ -43,36 +34,6 @@ export const getAbiDeclaration = (abi: any, interfaceName: string): string => {
 
 	const combinedContractInterface = `${contractInterface}\n${connectedContractInterface}${connectedContractConstructor}`
 	return combinedContractInterface;
-}
-
-export const parseAbi = (abi: any[]): AbiObject => {
-	const abiObject: AbiObject = {overloadedFunctions: {}, regularFunctions: {}, constructorFunction: {}}
-	//extract all functions
-	abi = abi.filter(functionObject => {
-		const {name, type, ...rest} = functionObject;
-		return (type === 'function' || type === 'constructor') ? true : false
-	})
-	//sort sort function types into their respective categories (functions, overloaded functions, constructor)
-	//TODO add support for events and fallback later
-	abi.map(functionObject => {
-		const { type } = functionObject
-		if(type === 'constructor'){
-			abiObject.constructorFunction = functionObject;
-			return abiObject;
-		} else {
-			const { name, ...values } = functionObject
-			if(abiObject.overloadedFunctions[name]){
-				abiObject.overloadedFunctions[name].push({...values})
-			} else if(abiObject.regularFunctions[name]){
-				abiObject.overloadedFunctions[name] = [{...values}]
-				abiObject.overloadedFunctions[name].push(abiObject.regularFunctions[name])
-				delete abiObject.regularFunctions[name]
-			} else {
-				abiObject.regularFunctions[name] = {...values}
-			}
-		}
-	})
-	return abiObject;
 }
 
 const parseOverloadedFunctions = (overloadedFunctions: FunctionDefinition[], connected?: boolean) => {

--- a/lib/src/builder/getAbiDeclaration.ts
+++ b/lib/src/builder/getAbiDeclaration.ts
@@ -1,3 +1,4 @@
+import { defaultProperties } from './staticContent';
 import { functionDefinition } from '../Types/AbiTypes';
 import { getPath, getName, getDetails } from './utils'
 import { Output } from '../io';
@@ -35,8 +36,8 @@ export const getAbiDeclaration = (abi: any, interfaceName: string, outputFile: s
 	})
  }
 
-	const contractInterface = `export interface I${interfaceName} {\n${abiTypings}}`
-	const connectedContractInterface = `export interface I${interfaceName}Connected {\n${connectedAbiTypings}}`
+	const contractInterface = `export interface I${interfaceName}{\n${abiTypings}}`
+	const connectedContractInterface = `export interface I${interfaceName}Connected {\n${defaultProperties}${connectedAbiTypings}}`
 
 	const combinedContractInterface = `${contractInterface}\n${connectedContractInterface}`
 	return combinedContractInterface;

--- a/lib/src/builder/getAbiDeclaration.ts
+++ b/lib/src/builder/getAbiDeclaration.ts
@@ -2,21 +2,76 @@ import { functionDefinition } from '../Types/AbiTypes';
 import { getPath, getName, getDetails } from './utils'
 import { Output } from '../io';
 
+declare interface AbiObject {
+	overloadedFunctions: {
+		[func: string]: functionDefinition[]
+	}
+	regularFunctions: {
+		[func: string]: functionDefinition
+	}
+}
+
 export const getAbiDeclaration = (abi: any, interfaceName: string, outputFile: string): string => {
  let abiTypings = '';
  let connectedAbiTypings = '';
  let parameterCount = 0;
- abi.forEach((functionDefinition: functionDefinition) => {
-	const {name, type} = functionDefinition
-	if(type !== 'event' && type !== 'fallback'){
-		abiTypings += `${name ? `${name}` : `${interfaceName.charAt(0).toLowerCase() + interfaceName.slice(1)}`}: ${getDetails(functionDefinition)};\n`;
-		connectedAbiTypings += `${name ? `${name}` : `${interfaceName.charAt(0).toLowerCase() + interfaceName.slice(1)}`}: ${getDetails(functionDefinition, true)};\n`;
-	}
-})
+ const abiObject = parseAbi(abi);
+ if(abiObject.constructor) {
+	 const constructorName = `${interfaceName.charAt(0).toLowerCase() + interfaceName.slice(1)}`
+	 abiTypings += `${constructorName}: ${getDetails(abiObject.constructor)}\n`
+ }
+ if(abiObject.overloadedFunctions){
+	Object.keys(abiObject.overloadedFunctions).forEach((name: string) => {
+		abiTypings += `${name}: ${parseOverloadedFunctions(abiObject.overloadedFunctions[name])}\n`
+		connectedAbiTypings += `${name}: ${parseOverloadedFunctions(abiObject.overloadedFunctions[name], true)}\n`
+	 })
+ }
+ if(abiObject.regularFunctions){
+	Object.keys(abiObject.regularFunctions).forEach((name: string) => {
+		const func = abiObject.regularFunctions[name]
+		abiTypings += `${name}: ${getDetails(func)}\n`
+		connectedAbiTypings += `${name}: ${getDetails(func, true)};\n`
+	})
+ }
 
 	const contractInterface = `export interface I${interfaceName} {\n${abiTypings}}`
 	const connectedContractInterface = `export interface I${interfaceName}Connected {\n${connectedAbiTypings}}`
 
 	const combinedContractInterface = `${contractInterface}\n${connectedContractInterface}`
 	return combinedContractInterface;
+}
+
+const parseAbi = (abi: any[]): AbiObject => {
+	const abiObject: AbiObject = {overloadedFunctions: {}, regularFunctions: {}}
+	//extract all functions
+	abi = abi.filter(functionObject => {
+		const {name, type, ...rest} = functionObject;
+		return name && (type === 'function' || type === 'constructor') ? true : false
+	})
+	//sort sort function types into their respective categories (functions, overloaded functions, constructor)
+	//TODO add support for evens and fallback later
+	abi.map(functionObject => {
+		const {name, ...values} = functionObject
+		const { type } = functionObject
+		if(type === 'constructor'){
+			abiObject.constructor = {...values}
+		} else if(abiObject.overloadedFunctions[name]){
+			abiObject.overloadedFunctions[name].push({...values})
+		} else if(abiObject.regularFunctions[name]){
+			abiObject.overloadedFunctions[name] = [{...values}]
+			abiObject.overloadedFunctions[name].push(abiObject.regularFunctions[name])
+			delete abiObject.regularFunctions[name]
+		} else {
+			abiObject.regularFunctions[name] = {...values}
+		}
+	})
+	return abiObject;
+}
+
+const parseOverloadedFunctions = (overloadedFunctions: functionDefinition[], connected?: boolean) => {
+	let details = overloadedFunctions.map(func => {
+		return getDetails(func, connected)
+	})
+	details = [...new Set(details)] //remove duplicates, since multiple Solidity typings may sometimes convert 
+	return details.join(' | ')
 }

--- a/lib/src/builder/getAbiDeclaration.ts
+++ b/lib/src/builder/getAbiDeclaration.ts
@@ -4,6 +4,7 @@ import { getPath, getName, getDetails } from './utils'
 import { Output } from '../io';
 
 declare interface AbiObject {
+	constructorFunction: functionDefinition
 	overloadedFunctions: {
 		[func: string]: functionDefinition[]
 	}
@@ -15,12 +16,13 @@ declare interface AbiObject {
 export const getAbiDeclaration = (abi: any, interfaceName: string, outputFile: string): string => {
  let abiTypings = '';
  let connectedAbiTypings = '';
+ let constructorTypings = '';
  let parameterCount = 0;
  const abiObject = parseAbi(abi);
- if(abiObject.constructor) {
-	 connectedAbiTypings += `new: ${getDetails(abiObject.constructor, true)}\n`
+ if(abiObject.constructor && abiObject.constructorFunction.inputs) {
+	 constructorTypings += `${getDetails(abiObject.constructor, true)}\n`
  } else {
-	 connectedAbiTypings += `new: ABIFuncParamlessSendConnected\n`
+	 constructorTypings += `never\n`
  }
  if(abiObject.overloadedFunctions){
 	Object.keys(abiObject.overloadedFunctions).forEach((name: string) => {
@@ -37,34 +39,38 @@ export const getAbiDeclaration = (abi: any, interfaceName: string, outputFile: s
  }
 
 	const contractInterface = `export interface I${interfaceName}{\n${abiTypings}}`
-	const connectedContractInterface = `export interface I${interfaceName}Connected {\n${defaultProperties}${connectedAbiTypings}}`
+	const connectedContractInterface = `export interface I${interfaceName}Connected {\n${defaultProperties}${connectedAbiTypings}}\n`
+	const connectedContractConstructor = `export type I${interfaceName}Constructor = ${constructorTypings}`
 
-	const combinedContractInterface = `${contractInterface}\n${connectedContractInterface}`
+	const combinedContractInterface = `${contractInterface}\n${connectedContractInterface}${connectedContractConstructor}`
 	return combinedContractInterface;
 }
 
 const parseAbi = (abi: any[]): AbiObject => {
-	const abiObject: AbiObject = {overloadedFunctions: {}, regularFunctions: {}}
+	const abiObject: AbiObject = {overloadedFunctions: {}, regularFunctions: {}, constructorFunction: {}}
 	//extract all functions
 	abi = abi.filter(functionObject => {
 		const {name, type, ...rest} = functionObject;
-		return name && (type === 'function' || type === 'constructor') ? true : false
+		return (type === 'function' || type === 'constructor') ? true : false
 	})
 	//sort sort function types into their respective categories (functions, overloaded functions, constructor)
 	//TODO add support for evens and fallback later
 	abi.map(functionObject => {
-		const {name, ...values} = functionObject
 		const { type } = functionObject
 		if(type === 'constructor'){
-			abiObject.constructor = {...values}
-		} else if(abiObject.overloadedFunctions[name]){
-			abiObject.overloadedFunctions[name].push({...values})
-		} else if(abiObject.regularFunctions[name]){
-			abiObject.overloadedFunctions[name] = [{...values}]
-			abiObject.overloadedFunctions[name].push(abiObject.regularFunctions[name])
-			delete abiObject.regularFunctions[name]
+			abiObject.constructorFunction = functionObject;
+			return abiObject;
 		} else {
-			abiObject.regularFunctions[name] = {...values}
+			const { name, ...values } = functionObject
+			if(abiObject.overloadedFunctions[name]){
+				abiObject.overloadedFunctions[name].push({...values})
+			} else if(abiObject.regularFunctions[name]){
+				abiObject.overloadedFunctions[name] = [{...values}]
+				abiObject.overloadedFunctions[name].push(abiObject.regularFunctions[name])
+				delete abiObject.regularFunctions[name]
+			} else {
+				abiObject.regularFunctions[name] = {...values}
+			}
 		}
 	})
 	return abiObject;

--- a/lib/src/builder/getAbiDeclaration.ts
+++ b/lib/src/builder/getAbiDeclaration.ts
@@ -1,23 +1,22 @@
 import { defaultProperties } from './staticContent';
-import { functionDefinition } from '../Types/AbiTypes';
+import { FunctionDefinition } from '../Types/AbiTypes';
 import { getPath, getName, getDetails } from './utils'
 import { Output } from '../io';
 
 declare interface AbiObject {
-	constructorFunction: functionDefinition
+	constructorFunction: FunctionDefinition
 	overloadedFunctions: {
-		[func: string]: functionDefinition[]
+		[func: string]: FunctionDefinition[]
 	}
 	regularFunctions: {
-		[func: string]: functionDefinition
+		[func: string]: FunctionDefinition
 	}
 }
 
-export const getAbiDeclaration = (abi: any, interfaceName: string, outputFile: string): string => {
+export const getAbiDeclaration = (abi: any, interfaceName: string): string => {
  let abiTypings = '';
  let connectedAbiTypings = '';
  let constructorTypings = '';
- let parameterCount = 0;
  const abiObject = parseAbi(abi);
  if(abiObject.constructor && abiObject.constructorFunction.inputs) {
 	 constructorTypings += `${getDetails(abiObject.constructor, true)}\n`
@@ -46,7 +45,7 @@ export const getAbiDeclaration = (abi: any, interfaceName: string, outputFile: s
 	return combinedContractInterface;
 }
 
-const parseAbi = (abi: any[]): AbiObject => {
+export const parseAbi = (abi: any[]): AbiObject => {
 	const abiObject: AbiObject = {overloadedFunctions: {}, regularFunctions: {}, constructorFunction: {}}
 	//extract all functions
 	abi = abi.filter(functionObject => {
@@ -54,7 +53,7 @@ const parseAbi = (abi: any[]): AbiObject => {
 		return (type === 'function' || type === 'constructor') ? true : false
 	})
 	//sort sort function types into their respective categories (functions, overloaded functions, constructor)
-	//TODO add support for evens and fallback later
+	//TODO add support for events and fallback later
 	abi.map(functionObject => {
 		const { type } = functionObject
 		if(type === 'constructor'){
@@ -76,7 +75,7 @@ const parseAbi = (abi: any[]): AbiObject => {
 	return abiObject;
 }
 
-const parseOverloadedFunctions = (overloadedFunctions: functionDefinition[], connected?: boolean) => {
+const parseOverloadedFunctions = (overloadedFunctions: FunctionDefinition[], connected?: boolean) => {
 	let details = overloadedFunctions.map(func => {
 		return getDetails(func, connected)
 	})

--- a/lib/src/builder/getAbiDeclaration.ts
+++ b/lib/src/builder/getAbiDeclaration.ts
@@ -17,8 +17,9 @@ export const getAbiDeclaration = (abi: any, interfaceName: string, outputFile: s
  let parameterCount = 0;
  const abiObject = parseAbi(abi);
  if(abiObject.constructor) {
-	 const constructorName = `${interfaceName.charAt(0).toLowerCase() + interfaceName.slice(1)}`
-	 abiTypings += `${constructorName}: ${getDetails(abiObject.constructor)}\n`
+	 connectedAbiTypings += `new: ${getDetails(abiObject.constructor, true)}\n`
+ } else {
+	 connectedAbiTypings += `new: ABIFuncParamlessSendConnected\n`
  }
  if(abiObject.overloadedFunctions){
 	Object.keys(abiObject.overloadedFunctions).forEach((name: string) => {

--- a/lib/src/builder/index.ts
+++ b/lib/src/builder/index.ts
@@ -1,2 +1,3 @@
 export { interfaces, imports } from './staticContent';
 export { getAbiDeclaration } from './getAbiDeclaration'
+export { parseAbi } from './parseAbi'

--- a/lib/src/builder/parseAbi.ts
+++ b/lib/src/builder/parseAbi.ts
@@ -1,0 +1,31 @@
+import { FunctionDefinition, AbiObject } from './../types/AbiTypes';
+
+export const parseAbi = (abi: any[]): AbiObject => {
+	const abiObject: AbiObject = {overloadedFunctions: {}, regularFunctions: {}, constructorFunction: {}}
+	//extract all functions
+	abi = abi.filter(functionObject => {
+		const {name, type, ...rest} = functionObject;
+		return (type === 'function' || type === 'constructor') ? true : false
+	})
+	//sort sort function types into their respective categories (functions, overloaded functions, constructor)
+	//TODO add support for events and fallback later
+	abi.map(functionObject => {
+		const { type } = functionObject
+		if(type === 'constructor'){
+			abiObject.constructorFunction = functionObject;
+			return abiObject;
+		} else {
+			const { name, ...values } = functionObject
+			if(abiObject.overloadedFunctions[name]){
+				abiObject.overloadedFunctions[name].push({...values})
+			} else if(abiObject.regularFunctions[name]){
+				abiObject.overloadedFunctions[name] = [{...values}]
+				abiObject.overloadedFunctions[name].push(abiObject.regularFunctions[name])
+				delete abiObject.regularFunctions[name]
+			} else {
+				abiObject.regularFunctions[name] = {...values}
+			}
+		}
+	})
+	return abiObject;
+}

--- a/lib/src/builder/staticContent.ts
+++ b/lib/src/builder/staticContent.ts
@@ -46,3 +46,7 @@ interface ICallTxObj {
   data?: string;
 }
 `;
+
+export const defaultProperties = `address: string
+balance: Promise<BN>
+`

--- a/lib/src/builder/staticContent.ts
+++ b/lib/src/builder/staticContent.ts
@@ -24,10 +24,10 @@ interface ABIFuncSend<T> {
 }
 type ABIFuncCallConnected<T, K = void> = (x: T, txObj?: ICallTxObj) => Promise<K>;
 type ABIFuncParamlessCallConnected<T = void> = (txObj?: ICallTxObj) => Promise<T>;
-type ABIFuncSendConnected<T> = (x: T, txObj?: ITransactionObj) => Promise<string>;
-type ABIFuncParamlessSendConnected = (txObj?: ITransactionObj) => Promise<string>;
+type ABIFuncSendConnected<T> = (x: T, txObj?: ITransactionObject) => Promise<string>;
+type ABIFuncParamlessSendConnected = (txObj?: ITransactionObject) => Promise<string>;
 
-interface ITransactionObj {
+interface ITransactionObject {
   from?: string;
   to?: string;
   gas?: string;
@@ -49,4 +49,5 @@ interface ICallTxObj {
 
 export const defaultProperties = `address: string
 balance: Promise<BN>
+at: ABIFuncSendConnected<{address: string}>
 `

--- a/lib/src/builder/staticContent.ts
+++ b/lib/src/builder/staticContent.ts
@@ -44,10 +44,8 @@ interface ICallTxObj {
   gasPrice?: string;
   value?: string;
   data?: string;
-}
-`;
+}`;
 
 export const defaultProperties = `address: string
-balance: Promise<BN>
-at: ABIFuncSendConnected<{address: string}>
+balance: ABIFuncParamlessCallConnected
 `

--- a/lib/src/builder/staticContent.ts
+++ b/lib/src/builder/staticContent.ts
@@ -47,5 +47,4 @@ interface ICallTxObj {
 }`;
 
 export const defaultProperties = `address: string
-balance: ABIFuncParamlessCallConnected
 `

--- a/lib/src/builder/utils/convertTypings.ts
+++ b/lib/src/builder/utils/convertTypings.ts
@@ -9,13 +9,9 @@ const convert = (type: string) => {
 	} else if(addressExp.test(type)){
 		return type.match(/\[]/) ? 'string[]' : 'string'
 	} else if(bytesExp.test(type)){
-		return type.match(/\[]/) ? 'string[]' : 'string'
+		return type.match(/\[]/) ? 'string[]' : 'string | Buffer'
 	} else if(uintExp.test(type)) {
-		let returnType = 'BN'
-		if(type.match('\d+')){
-			const byteLength = Number(type.match('\d+'));
-			returnType = byteLength > 64 ? 'BN' : 'number'
-		}
+		let returnType = 'BN | Buffer'
 		returnType += type.match('\[]') ? '[]' : ''
 		return returnType;
 	}

--- a/lib/src/builder/utils/convertTypings.ts
+++ b/lib/src/builder/utils/convertTypings.ts
@@ -1,6 +1,6 @@
 const convert = (type: string) => {
 	const bytesExp = new RegExp(/^byte(s)?(\d+)?(\[])?$/, 'mg')
-	const uintExp = new RegExp(/^u?int(\d+)?(\[])?$/, 'mg')
+	const intExp = new RegExp(/^u?int(\d+)?(\[])?$/, 'mg')
 	const addressExp = new RegExp(/^address(\[])?$/, 'mg')
 	const boolExp = new RegExp(/^bool(\[])?$/)
 
@@ -9,13 +9,9 @@ const convert = (type: string) => {
 	} else if(addressExp.test(type)){
 		return type.match(/\[]/) ? 'string[]' : 'string'
 	} else if(bytesExp.test(type)){
-		return type.match(/\[]/) ? 'string[]' : 'string'
-	} else if(uintExp.test(type)) {
-		let returnType = 'BN'
-		if(type.match('\d+')){
-			const byteLength = Number(type.match('\d+'));
-			returnType = byteLength > 64 ? 'BN' : 'number'
-		}
+		return type.match(/\[]/) ? 'string[]' : 'string | Buffer'
+	} else if(intExp.test(type)) {
+		let returnType = 'BN | Buffer'
 		returnType += type.match('\[]') ? '[]' : ''
 		return returnType;
 	}

--- a/lib/src/builder/utils/convertTypings.ts
+++ b/lib/src/builder/utils/convertTypings.ts
@@ -1,6 +1,6 @@
 const convert = (type: string) => {
 	const bytesExp = new RegExp(/^byte(s)?(\d+)?(\[])?$/, 'mg')
-	const uintExp = new RegExp(/^uint(\d+)?(\[])?$/, 'mg')
+	const uintExp = new RegExp(/^u?int(\d+)?(\[])?$/, 'mg')
 	const addressExp = new RegExp(/^address(\[])?$/, 'mg')
 	const boolExp = new RegExp(/^bool(\[])?$/)
 

--- a/lib/src/builder/utils/getAbiSignature.ts
+++ b/lib/src/builder/utils/getAbiSignature.ts
@@ -1,14 +1,14 @@
-import { functionDefinition } from '../../Types/AbiTypes'
+import { FunctionDefinition } from '../../Types/AbiTypes'
  
-export const getAbiSignature = (functionDefinition: functionDefinition, connected?: boolean) => {
-	if (functionDefinition.constant) {
-		if (functionDefinition.inputs && functionDefinition.inputs.length > 0) {
+export const getAbiSignature = (functionDef: FunctionDefinition, connected?: boolean) => {
+	if (functionDef.constant) {
+		if (functionDef.inputs && functionDef.inputs.length > 0) {
 			return connected ? 'ABIFuncCallConnected' : 'ABIFuncCall'
 		} else {
 			return connected ? 'ABIFuncParamlessCallConnected' : 'ABIFuncParamlessCall'
 		}
 	} else {
-		if (functionDefinition.inputs && functionDefinition.inputs.length > 0) {
+		if (functionDef.inputs && functionDef.inputs.length > 0) {
 			return connected ? 'ABIFuncSendConnected' : 'ABIFuncSend'
 		} else {
 			return connected ? 'ABIFuncParamlessSendConnected' : 'ABIFuncParamlessSend'

--- a/lib/src/builder/utils/getDetails.ts
+++ b/lib/src/builder/utils/getDetails.ts
@@ -4,15 +4,15 @@ import { getAbiSignature } from './getAbiSignature'
 
 export const getDetails = (functionDef: functionDefinition, connected?: boolean) => {
 	const {name, inputs, outputs} = functionDef
-	const signature = getAbiSignature(functionDef);
+	const signature = getAbiSignature(functionDef, connected);
 	const inputsPresent = inputs && (inputs.length > 0);
 	const outputsPresent = outputs && (outputs.length > 0) && functionDef.constant;
 	const inputParams = inputsPresent ? `{${getParameters(inputs)}}` : null
 	const outputParams = outputsPresent ? `{${getParameters(outputs)}}` : null
 	if(inputsPresent || outputsPresent){
-		return `${getAbiSignature(functionDef, connected)}<${inputParams ? inputParams : ''}${inputParams && outputParams ? ',' : ''}${outputParams ? outputParams : ''}>`
+		return `${signature}<${inputParams ? inputParams : ''}${inputParams && outputParams ? ',' : ''}${outputParams ? outputParams : ''}>`
 	}
-	return `${getAbiSignature(functionDef)}`
+	return `${signature}`
 }
 
 const getParameters = (parametersDefinition: SolidityVariable[] | undefined, outputNames?: string[]) => {

--- a/lib/src/builder/utils/getDetails.ts
+++ b/lib/src/builder/utils/getDetails.ts
@@ -1,8 +1,8 @@
 import convert from './convertTypings';
-import { SolidityVariable, functionDefinition } from '../../Types/abiTypes';
+import { SolidityVariable, FunctionDefinition } from '../../Types/abiTypes';
 import { getAbiSignature } from './getAbiSignature'
 
-export const getDetails = (functionDef: functionDefinition, connected?: boolean) => {
+export const getDetails = (functionDef: FunctionDefinition, connected?: boolean) => {
 	const {name, inputs, outputs} = functionDef
 	const signature = getAbiSignature(functionDef, connected);
 	const inputsPresent = inputs && (inputs.length > 0);

--- a/lib/src/builder/utils/getDetails.ts
+++ b/lib/src/builder/utils/getDetails.ts
@@ -17,12 +17,12 @@ export const getDetails = (functionDef: functionDefinition, connected?: boolean)
 
 const getParameters = (parametersDefinition: SolidityVariable[] | undefined, outputNames?: string[]) => {
 	let count = 0;
-	let paramContents = ''
+	let paramContents;
 	if(parametersDefinition){
-		parametersDefinition.map(param => {
-			paramContents += `,${param.name ? `${param.name}` : `${count++}`}: ${convert(param.type)}`
+		paramContents = parametersDefinition.map(param => {
+			return `${param.name ? `${param.name}` : `${count++}`}: ${convert(param.type)}`
 		})
-		paramContents = paramContents.length > 0 ? paramContents.substr(1) : paramContents; //remove the leading comma
+		paramContents = paramContents.join(',')
 	}
 	return paramContents;
 }

--- a/lib/src/cli/options.ts
+++ b/lib/src/cli/options.ts
@@ -1,6 +1,6 @@
 export const optionDefinitions = [
     { name: 'files', alias: 'f', type: String, multiple: true },
     { name: 'outputConfigurations', alias: 'c', type: String, multiple: true},
-    { name: 'outputFiles', alias: 'o', type: String },
+    { name: 'outputFile', alias: 'o', type: String },
     { name: 'help', alias: 'h' }
 ]

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -30,7 +30,7 @@ export const buildTypedABIs = () => {
         if(outputConfigs[interfaceName]){
           abi = modifyOutputNames(abi, outputConfigs[interfaceName]);
         }
-        printer.print(getAbiDeclaration(abi, interfaceName, outputFile))
+        printer.print(getAbiDeclaration(abi, interfaceName))
       })
       printer.print(interfaces);
     }
@@ -43,14 +43,15 @@ export const buildTypedABIs = () => {
   }
 }
 
-const modifyOutputNames = (abi: any, outputConfig: string[]): any => {
+export const modifyOutputNames = (abi: any, outputConfig: string[]): any => {
   abi.forEach(func => {
     if(func.outputs && func.outputs.length > 0 && outputConfig[func.name]){
       const functionConfig = outputConfig[func.name]
       if(func.outputs.length === functionConfig.length){
-        for(var i in func.outputs){
-          func.outputs[i].name = functionConfig[i]
-        }
+        func.outputs.map(i => {
+          func.outputs[i].name = functionConfig[i];
+          i++
+        })
       } else {
         console.warn(`Output mappings for function ${func.name} are not equivalent between the output file and the abi. Defaulting to abi output names for ${func.name}`)
       }

--- a/lib/src/types/AbiTypes.ts
+++ b/lib/src/types/AbiTypes.ts
@@ -12,3 +12,13 @@ export interface SolidityVariable {
   name: string
   type: string
 }
+
+export interface AbiObject {
+	constructorFunction: FunctionDefinition
+	overloadedFunctions: {
+		[func: string]: FunctionDefinition[]
+	}
+	regularFunctions: {
+		[func: string]: FunctionDefinition
+	}
+}

--- a/lib/src/types/AbiTypes.ts
+++ b/lib/src/types/AbiTypes.ts
@@ -3,7 +3,9 @@ export interface functionDefinition {
   inputs?: SolidityVariable[]
   outputs?: SolidityVariable[]
 	constant?: boolean
-	type?: string
+  type?: string
+  payable?: boolean
+  stateMutability?: string
 }
 
 export interface SolidityVariable {

--- a/lib/src/types/AbiTypes.ts
+++ b/lib/src/types/AbiTypes.ts
@@ -1,4 +1,4 @@
-export interface functionDefinition {
+export interface FunctionDefinition {
   name?: string
   inputs?: SolidityVariable[]
   outputs?: SolidityVariable[]

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "CLI tool for creating typed definition files from ABI",
   "main": "index.js",
   "scripts": {
-    "tsc": "tsc --watch"
+    "tsc": "tsc",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/MyCryptoHQ/typ3-cli.git"
   },
-  "author": "Mike Stupich, Henry Nguyen, William Prado",
+  "author": "William Prado, Mike Stupich, Henry Nguyen",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/MyCryptoHQ/typ3-cli/issues"
@@ -18,13 +19,29 @@
   "homepage": "https://github.com/MyCryptoHQ/typ3-cli#readme",
   "devDependencies": {
     "@types/node": "^8.0.34",
-    "tslint": "^5.7.0",
+    "jest": "^22.4.2",
+    "tslint": "^5.9.1",
     "typescript": "^2.7.2"
   },
   "dependencies": {
+    "@types/jest": "^22.2.0",
     "command-line-args": "^4.0.7",
     "command-line-usage": "^4.0.1",
-    "require-relative": "^0.8.7"
+    "npm": "^5.7.1",
+    "require-relative": "^0.8.7",
+    "ts-jest": "^22.4.2",
+    "tslint-config-prettier": "^1.10.0"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js"
+    ],
+    "transform": {
+      "\\.(ts|tsx)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+    },
+    "testRegex": "/__tests__/.*\\.(ts|tsx|js)$"
   },
   "bin": {
     "typ3-cli": "./dist/index.js"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "transform": {
       "\\.(ts|tsx)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
-    "testRegex": "/__tests__/.*\\.(ts|tsx|js)$"
+    "testRegex": "/__tests__/.*\\.(ts|tsx)$"
   },
   "bin": {
     "typ3-cli": "./dist/index.js"

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,9 @@
 {
   "defaultSeverity": "error",
-  "extends": ["tslint:recommended", "tslint-react", "tslint-config-prettier"],
+  "extends": [
+    "tslint:recommended",
+    "tslint-config-prettier"
+  ],
   "jsRules": {
     "quotemark": false,
     "max-line-length": false,
@@ -15,18 +18,18 @@
     "prefer-method-signature": true,
     "arrow-parens": false,
     "no-unnecessary-type-assertion": true,
-    "array-type": [true, "array"],
-    "jsx-no-lambda": false,
+    "array-type": [
+      true,
+      "array"
+    ],
     "interface-name": false,
     "no-duplicate-imports": true,
     "no-console": false,
     "no-var-requires": false,
     "jsx-wrap-multiline": false,
     "comment-format": false,
-    "ordered-imports": false,
-    "react-anchor-blank-noopener": true,
-    "no-http-string": [true, "http://localhost:.*"],
-    "react-no-dangerous-html": true
+    "ordered-imports": false
   },
-  "rulesDirectory": ["node_modules/tslint-microsoft-contrib"]
+  "rulesDirectory": []
 }
+


### PR DESCRIPTION
This PR creates constructor signatures for each abi, which are used as an optional typing argument in defining a Connected Contract instance. Additionally, it defines an address member in each Contract interface, to be used in directing transaction calls at the contract. Finally, there are several small bug fixes and typos addressed on this branch.