### PR TITLE
Fix constructor declaration bug.

### DIFF
--- a/Testing/Expected/getAbiDeclaration.ts
+++ b/Testing/Expected/getAbiDeclaration.ts
@@ -11,7 +11,7 @@ export const getAbiDecTest1 = `export interface ITest1{
 export interface ITest1Connected {
 address: string
 }
-export type ITest1Constructor = ABIFuncParamlessSendConnected
+export type ITest1Constructor = ABIFuncSendConnected<{a: BN | Buffer,b: string | Buffer}>
 `
 
 export const getAbiDecTest2 = `export interface ITest2{

--- a/lib/src/builder/getAbiDeclaration.ts
+++ b/lib/src/builder/getAbiDeclaration.ts
@@ -9,8 +9,8 @@ export const getAbiDeclaration = (abi: any, interfaceName: string): string => {
  let connectedAbiTypings = '';
  let constructorTypings = '';
  const abiObject = parseAbi(abi);
- if(abiObject.constructor && abiObject.constructorFunction.inputs) {
-	 constructorTypings += `${getDetails(abiObject.constructor, true)}\n`
+ if(abiObject.constructorFunction && abiObject.constructorFunction.inputs) {
+	 constructorTypings += `${getDetails(abiObject.constructorFunction, true)}\n`
  } else {
 	 constructorTypings += `never\n`
  }


### PR DESCRIPTION
Fixes a typo in the creation of constructor typings that was constantly returning AbiFuncParamlessSend as the constructor typing.